### PR TITLE
Refactor taxonomy and content type schemas to accept JSON strings for…

### DIFF
--- a/src/schemas/taxonomySchemas.ts
+++ b/src/schemas/taxonomySchemas.ts
@@ -31,6 +31,8 @@ export const taxonomyGroupSchemas = {
     .optional()
     .describe("External ID of the taxonomy group (optional)"),
   terms: z
-    .array(taxonomyTermSchema)
-    .describe("Hierarchical structure of taxonomy terms"),
+    .string()
+    .describe(
+      'JSON string representing the hierarchical structure of taxonomy terms. Each term should have \'name\' and \'terms\' array for nested terms. Example: \'[{"name": "Technology", "terms": [{"name": "Web Development", "terms": []}]}]\'',
+    ),
 } as const;

--- a/src/tools/add-content-type-mapi.ts
+++ b/src/tools/add-content-type-mapi.ts
@@ -1,10 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createMapiClient } from "../clients/kontentClients.js";
-import {
-  contentGroupSchema,
-  elementSchema,
-} from "../schemas/contentTypeSchemas.js";
 import { handleMcpToolError } from "../utils/errorHandler.js";
 import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 
@@ -25,32 +21,51 @@ export const registerTool = (server: McpServer): void => {
         .optional()
         .describe("External ID of the content type (optional)"),
       elements: z
-        .array(elementSchema)
+        .string()
         .describe(
-          "Array of elements that define the structure of the content type",
+          'JSON string representing an array of element objects that define the structure of the content type. Each element should have \'type\', \'name\' and other properties based on the element type. Example: \'[{"type": "text", "name": "Title", "is_required": true}, {"type": "rich_text", "name": "Content"}]\'',
         ),
       content_groups: z
-        .array(contentGroupSchema)
+        .string()
         .optional()
-        .describe("Array of content groups (optional)"),
+        .describe(
+          'JSON string representing an array of content group objects (optional). Example: \'[{"name": "General", "codename": "general"}]\'',
+        ),
     },
     async ({ name, codename, external_id, elements, content_groups }) => {
       const client = createMapiClient();
 
       try {
+        // Parse JSON strings
+        const parsedElements = JSON.parse(elements);
+        const parsedContentGroups = content_groups
+          ? JSON.parse(content_groups)
+          : undefined;
+
         const response = await client
           .addContentType()
           .withData(() => ({
             name,
             codename,
             external_id,
-            elements,
-            content_groups,
+            elements: parsedElements,
+            content_groups: parsedContentGroups,
           }))
           .toPromise();
 
         return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
+        if (error instanceof SyntaxError) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `JSON parsing error: ${error.message}. Please ensure 'elements' and 'content_groups' (if provided) are valid JSON strings.`,
+              },
+            ],
+            isError: true,
+          };
+        }
         return handleMcpToolError(error, "Content Type Creation");
       }
     },

--- a/src/tools/add-content-type-snippet-mapi.ts
+++ b/src/tools/add-content-type-snippet-mapi.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createMapiClient } from "../clients/kontentClients.js";
-import { snippetElementSchema } from "../schemas/contentTypeSchemas.js";
 import { handleMcpToolError } from "../utils/errorHandler.js";
 import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 
@@ -22,27 +21,41 @@ export const registerTool = (server: McpServer): void => {
         .optional()
         .describe("External ID of the content type snippet (optional)"),
       elements: z
-        .array(snippetElementSchema)
+        .string()
         .describe(
-          "Array of elements that define the structure of the content type snippet",
+          'JSON string representing an array of element objects that define the structure of the content type snippet. Each element should have \'type\', \'name\' and other properties based on the element type. Example: \'[{"type": "text", "name": "Title", "is_required": true}, {"type": "rich_text", "name": "Content"}]\'',
         ),
     },
     async ({ name, codename, external_id, elements }) => {
       const client = createMapiClient();
 
       try {
+        // Parse JSON string
+        const parsedElements = JSON.parse(elements);
+
         const response = await client
           .addContentTypeSnippet()
           .withData(() => ({
             name,
             codename,
             external_id,
-            elements,
+            elements: parsedElements,
           }))
           .toPromise();
 
         return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
+        if (error instanceof SyntaxError) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `JSON parsing error: ${error.message}. Please ensure 'elements' is a valid JSON string.`,
+              },
+            ],
+            isError: true,
+          };
+        }
         return handleMcpToolError(error, "Content Type Snippet Creation");
       }
     },


### PR DESCRIPTION
… terms and elements.

Gemini had a problem with arrays in the schemas. Now we use string that contain json representation of arrays.
