### PR TITLE
Use internal IDs instead of codenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,36 +62,36 @@ npx @kontent-ai/mcp-server@latest sse
 
 ### Content Type Management
 
-* **get-type-mapi** – Get a specific content type by codename
+* **get-type-mapi** – Get a specific content type by internal ID
 * **list-content-types-mapi** – List all content types in the environment
 * **add-content-type-mapi** – Create a new content type with elements
 
 ### Content Type Snippet Management
 
-* **get-type-snippet-mapi** – Get a specific content type snippet by codename
+* **get-type-snippet-mapi** – Get a specific content type snippet by internal ID
 * **list-content-type-snippets-mapi** – List all content type snippets
 * **add-content-type-snippet-mapi** – Create a new content type snippet
 
 ### Taxonomy Management
 
-* **get-taxonomy-group-mapi** – Get a specific taxonomy group by codename
+* **get-taxonomy-group-mapi** – Get a specific taxonomy group by internal ID
 * **list-taxonomy-groups-mapi** – List all taxonomy groups
 * **add-taxonomy-group-mapi** – Create a new taxonomy group with terms
 
 ### Content Item Management
 
-* **get-item-mapi** – Get a specific content item by codename
+* **get-item-mapi** – Get a specific content item by internal ID
 * **get-item-dapi** – Get a content item by codename from Delivery API
-* **get-variant-mapi** – Get a language variant of a content item
+* **get-variant-mapi** – Get a language variant of a content item by internal IDs
 * **add-content-item-mapi** – Create a new content item (structure only)
-* **update-content-item-mapi** – Update an existing content item by codename (name, collection)
-* **delete-content-item-mapi** – Delete a content item by codename
-* **upsert-language-variant-mapi** – Create or update a language variant with content
-* **delete-language-variant-mapi** – Delete a language variant of a content item
+* **update-content-item-mapi** – Update an existing content item by internal ID (name, collection)
+* **delete-content-item-mapi** – Delete a content item by internal ID
+* **upsert-language-variant-mapi** – Create or update a language variant with content using internal IDs
+* **delete-language-variant-mapi** – Delete a language variant of a content item by internal IDs
 
 ### Asset Management
 
-* **get-asset-mapi** – Get a specific asset by codename
+* **get-asset-mapi** – Get a specific asset by internal ID
 * **list-assets-mapi** – List all assets in the environment
 
 ### Language Management

--- a/src/schemas/contentItemSchemas.ts
+++ b/src/schemas/contentItemSchemas.ts
@@ -8,7 +8,7 @@ const referenceObjectSchema = z
     external_id: z.string().optional(),
   })
   .describe(
-    "An object with an id, codename, or external_id property referencing another item. Using codename is preferred for better readability.",
+    "An object with an id, codename, or external_id property referencing another item. Using id is preferred for better performance.",
   );
 
 // Language variant element value schemas

--- a/src/schemas/contentTypeSchemas.ts
+++ b/src/schemas/contentTypeSchemas.ts
@@ -7,7 +7,7 @@ const referenceObjectSchema = z
     codename: z.string().optional(),
   })
   .describe(
-    "An object with an id or codename property referencing another item. Using codename is preferred for better readability.",
+    "An object with an id or codename property referencing another item. Using id is preferred for better performance.",
   );
 
 // Common property schemas

--- a/src/tools/context/initial-context.ts
+++ b/src/tools/context/initial-context.ts
@@ -6,7 +6,7 @@ Kontent.ai is a headless content management system (CMS) that provides two main 
 ## Core Entities
 
 ### Content Items
-Content items are language-neutral content containers that serve as the foundation for your content structure. Each content item has a unique identifier and codename, and references a specific content type. The key relationship to understand is that one content item can have multiple language variants.
+Content items are language-neutral content containers that serve as the foundation for your content structure. Each content item has a unique internal ID and codename, and references a specific content type. The key relationship to understand is that one content item can have multiple language variants.
 
 ### Language Variants
 Language variants contain the actual language-specific content data including field values, workflow state, and language reference. Importantly, each variant is managed independently per language.
@@ -40,14 +40,14 @@ Example: If a content type has direct elements (title, body) and a metadata snip
 1. **Read the content type** to identify ALL taxonomy elements (type: "taxonomy")
 2. **Retrieve EACH taxonomy group definition** to understand the available terms and their hierarchical structure
 3. **Fill ALL taxonomy elements** in the language variant - DO NOT leave any taxonomy elements empty
-4. **Use appropriate term codenames** when filling taxonomy elements based on the content being created
+4. **Use appropriate term internal IDs** when filling taxonomy elements based on the content being created
 
 **MANDATORY REQUIREMENT**: Every taxonomy element in the content type MUST be filled with at least one appropriate term when creating language variants. Empty taxonomy elements are not acceptable and indicate incomplete content creation.
 
 **Example Process**: If a content type has three taxonomy elements:
-- "article_type" (required) → Must select appropriate type like "patient_education"
-- "topics" (optional but must be filled) → Must select relevant topics like "orthopedics", "surgery"
-- "medical_specialties" (optional but must be filled) → Must select relevant specialties
+- "article_type" (required) → Must select appropriate type using its internal ID
+- "topics" (optional but must be filled) → Must select relevant topics using their internal IDs
+- "medical_specialties" (optional but must be filled) → Must select relevant specialties using their internal IDs
 
 **Failure to fill ALL taxonomy elements will result in incomplete content creation and poor content organization.**
 
@@ -73,12 +73,38 @@ Example: If a content type has direct elements (title, body) and a metadata snip
 
 **Workflow states** manage the content lifecycle, tracking whether content is being drafted, is live, or has been archived.
 
-**Codenames** are human-readable unique identifiers that provide a consistent way to reference content programmatically.
+**Internal IDs** are unique identifiers that provide fast and reliable access to content entities. **ALWAYS use internal IDs when working with MCP tools for better performance and reliability.**
+
+**Codenames** are human-readable unique identifiers that provide a consistent way to reference content programmatically, but should be used primarily for readability and debugging.
 
 ## Best Practices
 
-Use snippets for common field groups to maintain consistency and avoid duplication. Plan your content types before creating content to ensure proper structure. Use meaningful codenames consistently throughout your project for better maintainability. Leverage taxonomies for organization to create logical content hierarchies. Consider your multilingual strategy early in the planning process to avoid restructuring later.
+Use snippets for common field groups to maintain consistency and avoid duplication. Plan your content types before creating content to ensure proper structure. **Always use internal IDs when working with MCP tools** for optimal performance and reliability. Leverage taxonomies for organization to create logical content hierarchies. Consider your multilingual strategy early in the planning process to avoid restructuring later.
 
 When working with snippets, always retrieve and understand the complete element structure before creating content variants.
 
-When working with taxonomy elements, always retrieve and understand the taxonomy group structure and available terms before creating content variants. **NEVER leave taxonomy elements empty - all taxonomy elements must be properly categorized.**`;
+When working with taxonomy elements, always retrieve and understand the taxonomy group structure and available terms before creating content variants. **NEVER leave taxonomy elements empty - all taxonomy elements must be properly categorized using internal IDs.**
+
+## MCP Tool Usage Guidelines
+
+**CRITICAL**: When using MCP tools, always prefer internal IDs over codenames:
+
+- **Content Items**: Use internal IDs to reference content items
+- **Language Variants**: Use internal IDs for both item and language references
+- **Content Types**: Use internal IDs to reference content types
+- **Taxonomy Terms**: Use internal IDs when referencing taxonomy terms
+- **Assets**: Use internal IDs when referencing assets
+- **Workflow Steps**: Use internal IDs for workflow step references
+
+**Why Internal IDs?** Internal IDs provide:
+- Better performance (faster lookups)
+- Immutability (won't change if names change)
+- Reliability (consistent across environments)
+- API efficiency (direct database lookups)
+
+**When to use codenames?** Codenames are useful for:
+- Human readability during development
+- Debugging and logging
+- Initial content setup when IDs are not yet known
+
+All MCP tools have been optimized to work with internal IDs for maximum efficiency.`;

--- a/src/tools/delete-content-item-mapi.ts
+++ b/src/tools/delete-content-item-mapi.ts
@@ -7,21 +7,21 @@ import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 export const registerTool = (server: McpServer): void => {
   server.tool(
     "delete-content-item-mapi",
-    "Delete a content item by codename from Management API",
+    "Delete a content item by internal ID from Management API",
     {
-      codename: z.string().describe("Codename of the content item to delete"),
+      id: z.string().describe("Internal ID of the content item to delete"),
     },
-    async ({ codename }) => {
+    async ({ id }) => {
       const client = createMapiClient();
 
       try {
         const response = await client
           .deleteContentItem()
-          .byItemCodename(codename)
+          .byItemId(id)
           .toPromise();
 
         return createMcpToolSuccessResponse({
-          message: `Content item '${codename}' deleted successfully`,
+          message: `Content item '${id}' deleted successfully`,
           deletedItem: response.data,
         });
       } catch (error: any) {

--- a/src/tools/delete-language-variant-mapi.ts
+++ b/src/tools/delete-language-variant-mapi.ts
@@ -9,23 +9,23 @@ export const registerTool = (server: McpServer): void => {
     "delete-language-variant-mapi",
     "Delete a language variant of a content item from Management API",
     {
-      itemCodename: z.string().describe("Codename of the content item"),
-      languageCodename: z
+      itemId: z.string().describe("Internal ID of the content item"),
+      languageId: z
         .string()
-        .describe("Codename of the language variant to delete"),
+        .describe("Internal ID of the language variant to delete"),
     },
-    async ({ itemCodename, languageCodename }) => {
+    async ({ itemId, languageId }) => {
       const client = createMapiClient();
 
       try {
         const response = await client
           .deleteLanguageVariant()
-          .byItemCodename(itemCodename)
-          .byLanguageCodename(languageCodename)
+          .byItemId(itemId)
+          .byLanguageId(languageId)
           .toPromise();
 
         return createMcpToolSuccessResponse({
-          message: `Language variant '${languageCodename}' of content item '${itemCodename}' deleted successfully`,
+          message: `Language variant '${languageId}' of content item '${itemId}' deleted successfully`,
           deletedVariant: response.data,
         });
       } catch (error: any) {

--- a/src/tools/get-asset-mapi.ts
+++ b/src/tools/get-asset-mapi.ts
@@ -7,17 +7,17 @@ import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 export const registerTool = (server: McpServer): void => {
   server.tool(
     "get-asset-mapi",
-    "Get a specific asset by codename from Management API",
+    "Get a specific asset by internal ID from Management API",
     {
-      assetCodename: z.string().describe("Codename of the asset to retrieve"),
+      assetId: z.string().describe("Internal ID of the asset to retrieve"),
     },
-    async ({ assetCodename }) => {
+    async ({ assetId }) => {
       const client = createMapiClient();
 
       try {
         const response = await client
           .viewAsset()
-          .byAssetCodename(assetCodename)
+          .byAssetId(assetId)
           .toPromise();
 
         return createMcpToolSuccessResponse(response.data);

--- a/src/tools/get-item-mapi.ts
+++ b/src/tools/get-item-mapi.ts
@@ -7,17 +7,17 @@ import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 export const registerTool = (server: McpServer): void => {
   server.tool(
     "get-item-mapi",
-    "Get Kontent.ai item by codename from Management API",
+    "Get Kontent.ai item by internal ID from Management API",
     {
-      codename: z.string().describe("Codename of the item to get"),
+      id: z.string().describe("Internal ID of the item to get"),
     },
-    async ({ codename }) => {
+    async ({ id }) => {
       const client = createMapiClient();
 
       try {
         const response = await client
           .viewContentItem()
-          .byItemCodename(codename)
+          .byItemId(id)
           .toPromise();
 
         return createMcpToolSuccessResponse(response.data);

--- a/src/tools/get-taxonomy-group-mapi.ts
+++ b/src/tools/get-taxonomy-group-mapi.ts
@@ -7,17 +7,17 @@ import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 export const registerTool = (server: McpServer): void => {
   server.tool(
     "get-taxonomy-group-mapi",
-    "Get taxonomy group by codename from Management API",
+    "Get taxonomy group by internal ID from Management API",
     {
-      codename: z.string().describe("Codename of the taxonomy group to get"),
+      id: z.string().describe("Internal ID of the taxonomy group to get"),
     },
-    async ({ codename }) => {
+    async ({ id }) => {
       const client = createMapiClient();
 
       try {
         const response = await client
           .getTaxonomy()
-          .byTaxonomyCodename(codename)
+          .byTaxonomyId(id)
           .toPromise();
 
         return createMcpToolSuccessResponse(response.data);

--- a/src/tools/get-type-mapi.ts
+++ b/src/tools/get-type-mapi.ts
@@ -7,17 +7,17 @@ import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 export const registerTool = (server: McpServer): void => {
   server.tool(
     "get-type-mapi",
-    "Get content type by codename from Management API",
+    "Get content type by internal ID from Management API",
     {
-      codename: z.string().describe("Codename of the content type to get"),
+      id: z.string().describe("Internal ID of the content type to get"),
     },
-    async ({ codename }) => {
+    async ({ id }) => {
       const client = createMapiClient();
 
       try {
         const response = await client
           .viewContentType()
-          .byTypeCodename(codename)
+          .byTypeId(id)
           .toPromise();
 
         return createMcpToolSuccessResponse(response.data);

--- a/src/tools/get-type-snippet-mapi.ts
+++ b/src/tools/get-type-snippet-mapi.ts
@@ -7,19 +7,17 @@ import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 export const registerTool = (server: McpServer): void => {
   server.tool(
     "get-type-snippet-mapi",
-    "Get content type snippet by codename from Management API",
+    "Get content type snippet by internal ID from Management API",
     {
-      codename: z
-        .string()
-        .describe("Codename of the content type snippet to get"),
+      id: z.string().describe("Internal ID of the content type snippet to get"),
     },
-    async ({ codename }) => {
+    async ({ id }) => {
       const client = createMapiClient();
 
       try {
         const response = await client
           .viewContentTypeSnippet()
-          .byTypeCodename(codename)
+          .byTypeId(id)
           .toPromise();
 
         return createMcpToolSuccessResponse(response.data);

--- a/src/tools/get-variant-mapi.ts
+++ b/src/tools/get-variant-mapi.ts
@@ -9,19 +9,19 @@ export const registerTool = (server: McpServer): void => {
     "get-variant-mapi",
     "Get language variant of a content item from Management API",
     {
-      itemCodename: z.string().describe("Codename of the content item"),
-      languageCodename: z
+      itemId: z.string().describe("Internal ID of the content item"),
+      languageId: z
         .string()
-        .describe("Codename of the language variant to get"),
+        .describe("Internal ID of the language variant to get"),
     },
-    async ({ itemCodename, languageCodename }) => {
+    async ({ itemId, languageId }) => {
       const client = createMapiClient();
 
       try {
         const response = await client
           .viewLanguageVariant()
-          .byItemCodename(itemCodename)
-          .byLanguageCodename(languageCodename)
+          .byItemId(itemId)
+          .byLanguageId(languageId)
           .toPromise();
 
         return createMcpToolSuccessResponse(response.data);

--- a/src/tools/update-content-item-mapi.ts
+++ b/src/tools/update-content-item-mapi.ts
@@ -7,9 +7,9 @@ import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 export const registerTool = (server: McpServer): void => {
   server.tool(
     "update-content-item-mapi",
-    "Update an existing content item by codename via Management API. The content item must already exist - this tool will not create new items.",
+    "Update an existing content item by internal ID via Management API. The content item must already exist - this tool will not create new items.",
     {
-      codename: z.string().describe("Codename of the content item to update"),
+      id: z.string().describe("Internal ID of the content item to update"),
       name: z
         .string()
         .min(1)
@@ -29,12 +29,12 @@ export const registerTool = (server: McpServer): void => {
           "Reference to a collection by id, codename, or external_id (optional)",
         ),
     },
-    async ({ codename, name, collection }) => {
+    async ({ id, name, collection }) => {
       const client = createMapiClient();
 
       try {
         // First, verify the item exists by trying to get it
-        await client.viewContentItem().byItemCodename(codename).toPromise();
+        await client.viewContentItem().byItemId(id).toPromise();
 
         // If we get here, the item exists, so we can update it
         const updateData: any = {};
@@ -62,12 +62,12 @@ export const registerTool = (server: McpServer): void => {
 
         const response = await client
           .upsertContentItem()
-          .byItemCodename(codename)
+          .byItemId(id)
           .withData(updateData)
           .toPromise();
 
         return createMcpToolSuccessResponse({
-          message: `Content item '${codename}' updated successfully`,
+          message: `Content item '${id}' updated successfully`,
           updatedItem: response.rawData,
         });
       } catch (error: any) {
@@ -80,7 +80,7 @@ export const registerTool = (server: McpServer): void => {
             content: [
               {
                 type: "text",
-                text: `Update Content Item: Content item with codename '${codename}' does not exist. Use add-content-item-mapi to create new items.`,
+                text: `Update Content Item: Content item with ID '${id}' does not exist. Use add-content-item-mapi to create new items.`,
               },
             ],
             isError: true,


### PR DESCRIPTION
The MCP server currently uses codenames for entity references, but this confuses AI agents (who make up non-existent codenames) and hurts performance (requiring multiple API calls to find entities). The proposed solution is switching to internal IDs, which testing shows significantly improves agent performance and eliminates both issues.