### PR TITLE
EN-586 Use raw data in the tooling responses

### DIFF
--- a/src/tools/add-taxonomy-group-mapi.ts
+++ b/src/tools/add-taxonomy-group-mapi.ts
@@ -22,7 +22,7 @@ export const registerTool = (
           .withData(taxonomyGroup)
           .toPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Taxonomy Group Creation");
       }

--- a/src/tools/change-variant-workflow-step-mapi.ts
+++ b/src/tools/change-variant-workflow-step-mapi.ts
@@ -61,7 +61,7 @@ export const registerTool = (
 
         return createMcpToolSuccessResponse({
           message: `Successfully changed workflow step of language variant '${languageId}' for content item '${itemId}' to workflow step '${workflowStepId}'`,
-          result: response.data,
+          result: response.rawData,
         });
       } catch (error: any) {
         return handleMcpToolError(error, "Workflow Step Change");

--- a/src/tools/create-variant-version-mapi.ts
+++ b/src/tools/create-variant-version-mapi.ts
@@ -38,7 +38,7 @@ export const registerTool = (
 
         return createMcpToolSuccessResponse({
           message: `Successfully created new version of language variant '${languageId}' for content item '${itemId}'`,
-          result: response.data,
+          result: response.rawData,
         });
       } catch (error: any) {
         return handleMcpToolError(error, "Variant Version Creation");

--- a/src/tools/delete-content-item-mapi.ts
+++ b/src/tools/delete-content-item-mapi.ts
@@ -26,7 +26,7 @@ export const registerTool = (
 
         return createMcpToolSuccessResponse({
           message: `Content item '${id}' deleted successfully`,
-          deletedItem: response.data,
+          deletedItem: response.rawData,
         });
       } catch (error: any) {
         return handleMcpToolError(error, "Content Item Deletion");

--- a/src/tools/delete-content-type-mapi.ts
+++ b/src/tools/delete-content-type-mapi.ts
@@ -26,7 +26,7 @@ export const registerTool = (
 
         return createMcpToolSuccessResponse({
           message: `Content type '${codename}' deleted successfully`,
-          deletedType: response.data,
+          deletedType: response.rawData,
         });
       } catch (error: unknown) {
         return handleMcpToolError(error, "Content Type Deletion");

--- a/src/tools/delete-language-variant-mapi.ts
+++ b/src/tools/delete-language-variant-mapi.ts
@@ -30,7 +30,7 @@ export const registerTool = (
 
         return createMcpToolSuccessResponse({
           message: `Language variant '${languageId}' of content item '${itemId}' deleted successfully`,
-          deletedVariant: response.data,
+          deletedVariant: response.rawData,
         });
       } catch (error: any) {
         return handleMcpToolError(error, "Language Variant Deletion");

--- a/src/tools/get-asset-mapi.ts
+++ b/src/tools/get-asset-mapi.ts
@@ -24,7 +24,7 @@ export const registerTool = (
           .byAssetId(assetId)
           .toPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Asset Retrieval");
       }

--- a/src/tools/get-item-mapi.ts
+++ b/src/tools/get-item-mapi.ts
@@ -24,7 +24,7 @@ export const registerTool = (
           .byItemId(id)
           .toPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Item Retrieval");
       }

--- a/src/tools/get-taxonomy-group-mapi.ts
+++ b/src/tools/get-taxonomy-group-mapi.ts
@@ -24,7 +24,7 @@ export const registerTool = (
           .byTaxonomyId(id)
           .toPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Taxonomy Group Retrieval");
       }

--- a/src/tools/get-type-mapi.ts
+++ b/src/tools/get-type-mapi.ts
@@ -24,7 +24,7 @@ export const registerTool = (
           .byTypeId(id)
           .toPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Content Type Retrieval");
       }

--- a/src/tools/get-type-snippet-mapi.ts
+++ b/src/tools/get-type-snippet-mapi.ts
@@ -24,7 +24,7 @@ export const registerTool = (
           .byTypeId(id)
           .toPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Content Type Snippet Retrieval");
       }

--- a/src/tools/get-variant-mapi.ts
+++ b/src/tools/get-variant-mapi.ts
@@ -28,7 +28,7 @@ export const registerTool = (
           .byLanguageId(languageId)
           .toPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Language Variant Retrieval");
       }

--- a/src/tools/list-assets-mapi.ts
+++ b/src/tools/list-assets-mapi.ts
@@ -18,7 +18,9 @@ export const registerTool = (
       try {
         const response = await client.listAssets().toAllPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        const rawData = response.responses.flatMap((r) => r.rawData.assets);
+
+        return createMcpToolSuccessResponse(rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Assets Listing");
       }

--- a/src/tools/list-content-type-snippets-mapi.ts
+++ b/src/tools/list-content-type-snippets-mapi.ts
@@ -18,7 +18,9 @@ export const registerTool = (
       try {
         const response = await client.listContentTypeSnippets().toAllPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        const rawData = response.responses.flatMap((r) => r.rawData.snippets);
+
+        return createMcpToolSuccessResponse(rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Content Type Snippets Listing");
       }

--- a/src/tools/list-content-types-mapi.ts
+++ b/src/tools/list-content-types-mapi.ts
@@ -18,7 +18,9 @@ export const registerTool = (
       try {
         const response = await client.listContentTypes().toAllPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        const rawData = response.responses.flatMap((r) => r.rawData.types);
+
+        return createMcpToolSuccessResponse(rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Content Types Listing");
       }

--- a/src/tools/list-languages-mapi.ts
+++ b/src/tools/list-languages-mapi.ts
@@ -18,7 +18,9 @@ export const registerTool = (
       try {
         const response = await client.listLanguages().toAllPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        const rawData = response.responses.flatMap((r) => r.rawData.languages);
+
+        return createMcpToolSuccessResponse(rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Languages Listing");
       }

--- a/src/tools/list-taxonomy-groups-mapi.ts
+++ b/src/tools/list-taxonomy-groups-mapi.ts
@@ -18,7 +18,9 @@ export const registerTool = (
       try {
         const response = await client.listTaxonomies().toAllPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        const rawData = response.responses.flatMap((r) => r.rawData.taxonomies);
+
+        return createMcpToolSuccessResponse(rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Taxonomy Groups Listing");
       }

--- a/src/tools/list-workflows-mapi.ts
+++ b/src/tools/list-workflows-mapi.ts
@@ -18,7 +18,7 @@ export const registerTool = (
       try {
         const response = await client.listWorkflows().toPromise();
 
-        return createMcpToolSuccessResponse(response.data);
+        return createMcpToolSuccessResponse(response.rawData);
       } catch (error: any) {
         return handleMcpToolError(error, "Workflows Listing");
       }


### PR DESCRIPTION
### Motivation

The tooling was inconsistent in what it was returning. Also, returning data caused some data duplication as those data had also the _raw property that contained the same data in the raw format. This should fix both those issues.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
