### PR TITLE
KCL-14800 Extract search results from cumulative response wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontent-ai/mcp-server",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "type": "module",
   "mcpName": "io.github.kontent-ai/mcp-server",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/kontent-ai/mcp-server",
     "source": "github"
   },
-  "version": "0.30.1",
+  "version": "0.31.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@kontent-ai/mcp-server",
-      "version": "0.30.1",
+      "version": "0.31.0",
       "transport": {
         "type": "stdio"
       },
@@ -41,7 +41,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@kontent-ai/mcp-server",
-      "version": "0.30.1",
+      "version": "0.31.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:3001/{KONTENT_ENVIRONMENT_ID}/mcp"

--- a/src/tools/search-variants-mapi.ts
+++ b/src/tools/search-variants-mapi.ts
@@ -17,6 +17,7 @@ interface AiOperationResultResponse {
 
 interface AiOperationResult {
   isFinished: boolean;
+  value?: string;
 }
 
 class OperationResultIncompleteError extends Error {
@@ -25,6 +26,25 @@ class OperationResultIncompleteError extends Error {
     this.name = "OperationResultIncompleteError";
   }
 }
+
+const isSearchResponseWrapper = (
+  value: unknown,
+): value is { searchResults: string } =>
+  typeof value === "object" && value !== null && "searchResults" in value;
+
+const extractSearchResults = (response: AiOperationResultResponse): object => {
+  const value = response.result?.value;
+  if (!value) {
+    return {};
+  }
+
+  const parsed = JSON.parse(value);
+  if (isSearchResponseWrapper(parsed)) {
+    return JSON.parse(parsed.searchResults);
+  }
+
+  return parsed;
+};
 
 export const registerTool = (server: McpServer): void => {
   server.tool(
@@ -125,8 +145,10 @@ export const registerTool = (server: McpServer): void => {
           },
         );
 
+        const searchResults = extractSearchResults(resultData);
+
         return createMcpToolSuccessResponse({
-          result: resultData,
+          result: searchResults,
         });
       } catch (error: unknown) {
         return handleMcpToolError(error, "AI-powered Variant Search");


### PR DESCRIPTION
### Motivation

AI service changes how search responses are structured. Previously, two separate messages were sent: a filter message and a search results message. The new format sends a single cumulative message containing both filter and results wrapped in { extractedFilter, searchResults }. The `search-variants-mapi` tool needs to adapt this behavior.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

