### PR TITLE
﻿EN-786 - surface variant editability from MAPI, add cancel-scheduled-publishing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ npx @kontent-ai/mcp-server@latest shttp
 ### Content Item Management
 
 * **get-content-item** – Get Kontent.ai content item by ID
-* **get-content-item-variant** – Retrieve Kontent.ai content item variant (language version/translation). Returns the current version — draft if one exists, otherwise published
-* **get-published-content-item-variant-version** – Retrieve the published version of a Kontent.ai content item variant. Use when a newer draft version exists but you need the currently published (live) content
-* **get-content-item-translations** – Get all Kontent.ai content item translations — every language version (variant) of a specific content item
+* **get-content-item-variant** – Retrieve Kontent.ai content item variant (language version/translation). Returns the current version — draft if one exists, otherwise published. Includes `agent_metadata.editability` returned by the Management API indicating whether the variant can be updated directly or which operation must happen first (creating a new version, canceling scheduled publishing, or changing the workflow step)
+* **get-published-content-item-variant-version** – Retrieve the published version of a Kontent.ai content item variant. Use when a newer draft version exists but you need the currently published (live) content. Includes `agent_metadata.editability` explaining that the snapshot can't be updated and how to edit the variant via its current version
+* **get-content-item-translations** – Get all Kontent.ai content item translations — every language version (variant) of a specific content item. Each variant includes `agent_metadata.editability` indicating whether it can be updated directly or which operation must happen first
 * **list-content-item-variants** – List, filter, search Kontent.ai content items with content item variants (language versions/translations)
 * **create-content-item** – Create new Kontent.ai content item (creates the container only, use create-content-item-variant to add language versions/translations)
 * **update-content-item** – Update existing Kontent.ai content item by ID. The content item must already exist - this tool will not create new items
@@ -103,7 +103,7 @@ npx @kontent-ai/mcp-server@latest shttp
 * **update-content-item-variant** – Update Kontent.ai content item variant of a content item. Element values must fulfill limitations and guidelines defined in content type. Send only the elements you want to change — omitted elements are left untouched. For rich-text elements with components, submit the full element (value plus the complete components array, including components that are left untouched)
 * **create-new-content-item-variant-version** – Create new version of Kontent.ai content item variant. This operation creates a new version of an existing content item variant, useful for content versioning and creating new drafts from published content
 * **delete-content-item-variant** – Delete Kontent.ai content item variant
-* **bulk-get-content-item-variants** – Bulk get Kontent.ai content items with their content item variants by item and language reference pairs. Use after list-content-item-variants to retrieve full content data for specific item+language pairs. Items without a variant in the requested language return the item without the variant property. Returns paginated results with continuation token
+* **bulk-get-content-item-variants** – Bulk get Kontent.ai content items with their content item variants by item and language reference pairs. Use after list-content-item-variants to retrieve full content data for specific item+language pairs. Items without a variant in the requested language return the item without the variant property. Returns paginated results with continuation token. Each variant includes `agent_metadata.editability` indicating whether it can be updated directly or which operation must happen first
 * **search-content-item-variants** – AI-powered semantic search for finding content by meaning and concepts in a specific content item variant. Use for: conceptual searches when you don't know exact keywords. Limited filtering options (variant ID only)
 
 ### Asset Management
@@ -145,9 +145,10 @@ npx @kontent-ai/mcp-server@latest shttp
 * **create-workflow** – Create new Kontent.ai workflow with custom steps, transitions, scopes, and role permissions
 * **update-workflow** – Update an existing Kontent.ai workflow by ID. Modify steps, transitions, scopes, and role permissions. Cannot remove steps that are in use
 * **delete-workflow** – Delete a Kontent.ai workflow by ID. The workflow must not be in use by any content items
-* **change-content-item-variant-workflow-step** – Change the workflow step of a content item variant in Kontent.ai. This operation moves a content item variant to a different step in the workflow, enabling content lifecycle management such as moving content from draft to review, review to published, etc.
+* **change-content-item-variant-workflow-step** – Change the workflow step of a content item variant in Kontent.ai. This operation moves a content item variant to a different step in the workflow, enabling content lifecycle management such as moving content from draft to review, review to published, etc. Use list-workflows to discover the workflow's steps and their IDs — the workflow's `steps` are the editable ones, as opposed to the published, scheduled, and archived system steps.
 * **publish-content-item-variant** – Publish or schedule a content item variant of a content item in Kontent.ai. This operation can either immediately publish the variant or schedule it for publication at a specific future date and time with optional timezone specification
 * **unpublish-content-item-variant** – Unpublish or schedule unpublishing of a content item variant of a content item in Kontent.ai. This operation can either immediately unpublish the variant (making it unavailable through the Delivery API) or schedule it for unpublishing at a specific future date and time with optional timezone specification
+* **cancel-scheduled-publishing-content-item-variant** – Cancel scheduled publishing of a Kontent.ai content item variant. Reverts a variant that is scheduled to publish back to its previous workflow step so it can be edited again. Use before updating a variant that is in the Scheduled workflow step
 
 ## ⚙️ Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.37.0",
       "license": "MIT",
       "dependencies": {
-        "@kontent-ai/management-sdk": "8.5.1",
+        "@kontent-ai/management-sdk": "8.6.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "applicationinsights": "2.9.8",
         "dotenv": "17.4.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Jiri Lojda",
   "license": "MIT",
   "dependencies": {
-    "@kontent-ai/management-sdk": "8.5.1",
+    "@kontent-ai/management-sdk": "8.6.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "applicationinsights": "2.9.8",
     "dotenv": "17.4.1",

--- a/src/test/bm25/toolSearchBm25.spec.ts
+++ b/src/test/bm25/toolSearchBm25.spec.ts
@@ -736,6 +736,19 @@ const testGroups: ReadonlyArray<TestGroup> = [
         query: "take content offline",
         expected: [allTools.unpublishContentItemVariant.name],
       },
+      // cancel scheduled publishing
+      {
+        query: "cancel scheduled publishing",
+        expected: [allTools.cancelScheduledPublishingContentItemVariant.name],
+      },
+      {
+        query: "cancel scheduled publish variant",
+        expected: [allTools.cancelScheduledPublishingContentItemVariant.name],
+      },
+      {
+        query: "unschedule variant publishing",
+        expected: [allTools.cancelScheduledPublishingContentItemVariant.name],
+      },
       // Synonym: approve / review / lifecycle / archive
       {
         query: "approve content review",

--- a/src/test/security/server.spec.ts
+++ b/src/test/security/server.spec.ts
@@ -14,6 +14,7 @@ type ToolKind = "read-only" | "additive" | "destructive" | "unknown";
 const READ_ONLY_PREFIXES = ["bulk-get-", "get-", "list-", "search-"];
 const ADDITIVE_PREFIXES = ["create-"];
 const DESTRUCTIVE_PREFIXES = [
+  "cancel-",
   "change-",
   "delete-",
   "patch-",

--- a/src/test/tools/allTools.spec.ts
+++ b/src/test/tools/allTools.spec.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, it } from "mocha";
 import { allTools } from "../../tools/index.js";
+import * as referencedToolNames from "../../tools/referencedToolNames.js";
 
 // Guards against the easy mistake of adding a new tool file under src/tools but
 // forgetting to register it in src/tools/index.ts (allTools) — or leaving a
@@ -67,5 +68,25 @@ describe("allTools registry", () => {
       discoveredNames,
       "allTools (src/tools/index.ts) must list every tool defined under src/tools and nothing that no longer exists",
     );
+  });
+});
+
+// Tool descriptions point agents at other tools by name (e.g. the EN-786
+// editability guidance tells the agent which tool resolves a non-editable
+// variant). Those references go through referencedToolNames.ts, so a renamed or
+// deleted tool would otherwise leave a description sending the agent to a tool
+// that does not exist — a silent failure, since nothing loads the name.
+describe("referencedToolNames", () => {
+  it("only names tools that are actually registered", () => {
+    const registeredNames = new Set(
+      Object.values(allTools).map((tool) => tool.name),
+    );
+
+    for (const [constant, toolName] of Object.entries(referencedToolNames)) {
+      assert.ok(
+        registeredNames.has(toolName),
+        `${constant} is "${toolName}", which is not a registered tool`,
+      );
+    }
   });
 });

--- a/src/test/tools/get-content-item-variant.spec.ts
+++ b/src/test/tools/get-content-item-variant.spec.ts
@@ -1,0 +1,50 @@
+import * as assert from "node:assert";
+import { describe, it } from "mocha";
+import { bulkGetContentItemVariants } from "../../tools/bulk-get-content-item-variants.js";
+import { getContentItemTranslations } from "../../tools/get-content-item-translations.js";
+import { getContentItemVariant } from "../../tools/get-content-item-variant.js";
+import { getPublishedContentItemVariantVersion } from "../../tools/get-published-content-item-variant-version.js";
+
+// The Management API returns 'agent_metadata.editability' for this tool (EN-786;
+// the request opts in via the X-KC-Agent-Metadata header sent by the SDK's
+// withAgentMetadata()), so the description has to point the agent at it.
+// The guidance itself names the operation to perform, and it travels in the
+// response body rather than the description — which is why the description does
+// not name the tools that carry those operations out. Doing so would duplicate
+// their name tokens into this tool's search document; see src/test/bm25/CLAUDE.md
+// ("Two description anti-patterns...").
+describe("get-content-item-variant description (EN-786)", () => {
+  it("documents the agent metadata editability contract", () => {
+    assert.match(
+      getContentItemVariant.description,
+      /agent_metadata\.editability/,
+    );
+    assert.match(getContentItemVariant.description, /is_editable/);
+    assert.match(getContentItemVariant.description, /guidance/);
+  });
+});
+
+// The list, bulk-get and published-version tools request the same metadata from
+// the Management API; their descriptions must point the agent at it too.
+describe("variant tools returning agent metadata (EN-786)", () => {
+  const toolsWithAgentMetadata = [
+    getContentItemTranslations,
+    bulkGetContentItemVariants,
+    getPublishedContentItemVariantVersion,
+  ];
+
+  it("document the agent metadata editability guidance", () => {
+    for (const tool of toolsWithAgentMetadata) {
+      assert.match(
+        tool.description,
+        /agent_metadata/,
+        `Expected ${tool.name} description to mention agent_metadata`,
+      );
+      assert.match(
+        tool.description,
+        /guidance/,
+        `Expected ${tool.name} description to mention guidance`,
+      );
+    }
+  });
+});

--- a/src/tools/bulk-get-content-item-variants.ts
+++ b/src/tools/bulk-get-content-item-variants.ts
@@ -8,7 +8,7 @@ import { defineReadOnlyTool } from "./toolDefinition.js";
 
 export const bulkGetContentItemVariants = defineReadOnlyTool(
   bulkGetContentItemVariantsToolName,
-  "Bulk/batch retrieve full details and content for multiple (2 or more) Kontent.ai content item variants by item and language reference pairs. Fetch full content for several items whose IDs were found via other tools.",
+  "Bulk/batch retrieve full details and content for multiple (2 or more) Kontent.ai content item variants by item and language reference pairs. Fetch full content for several items whose IDs were found via other tools. Each variant includes 'agent_metadata.editability': 'is_editable' plus plain-text 'guidance' naming the operation required first when a variant is not directly editable.",
   bulkGetItemsWithVariantsSchema.shape,
   async (
     { variants, continuation_token },
@@ -22,9 +22,12 @@ export const bulkGetContentItemVariants = defineReadOnlyTool(
 
       const client = createMapiClient(environmentId, token);
 
-      const query = client.bulkGetItemsWithVariants().withData({
-        variants,
-      });
+      const query = client
+        .bulkGetItemsWithVariants()
+        .withData({
+          variants,
+        })
+        .withAgentMetadata();
 
       const response = await (continuation_token
         ? query.xContinuationToken(continuation_token)

--- a/src/tools/cancel-scheduled-publishing-content-item-variant.ts
+++ b/src/tools/cancel-scheduled-publishing-content-item-variant.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { createMapiClient } from "../clients/kontentClients.js";
+import { handleMcpToolError } from "../utils/errorHandler.js";
+import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
+import { cancelScheduledPublishingContentItemVariantToolName } from "./referencedToolNames.js";
+import { defineDestructiveTool } from "./toolDefinition.js";
+
+export const cancelScheduledPublishingContentItemVariant =
+  defineDestructiveTool(
+    cancelScheduledPublishingContentItemVariantToolName,
+    "Cancel scheduled publishing of a Kontent.ai content item variant (language version/translation). Reverts a variant that is scheduled to publish back to its previous workflow step so it can be edited again. Use this before updating a variant that is in the Scheduled workflow step.",
+    {
+      itemId: z.guid().describe("Content item ID"),
+      languageId: z
+        .guid()
+        .describe(
+          "Language ID (default: 00000000-0000-0000-0000-000000000000)",
+        ),
+    },
+    async ({ itemId, languageId }, { authInfo: { token, clientId } = {} }) => {
+      const client = createMapiClient(clientId, token);
+
+      try {
+        await client
+          .cancelSheduledPublishingOfLanguageVariant()
+          .byItemId(itemId)
+          .byLanguageId(languageId)
+          .toPromise();
+
+        return createMcpToolSuccessResponse({
+          message: `Successfully canceled scheduled publishing of item variant '${languageId}' for content item '${itemId}'. The variant is no longer scheduled and can now be updated.`,
+        });
+      } catch (error: unknown) {
+        return handleMcpToolError(
+          error,
+          "Cancel Scheduled Publishing of Language Variant",
+        );
+      }
+    },
+  );

--- a/src/tools/change-content-item-variant-workflow-step.ts
+++ b/src/tools/change-content-item-variant-workflow-step.ts
@@ -2,11 +2,12 @@ import { z } from "zod";
 import { createMapiClient } from "../clients/kontentClients.js";
 import { handleMcpToolError } from "../utils/errorHandler.js";
 import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
+import { changeContentItemVariantWorkflowStepToolName } from "./referencedToolNames.js";
 import { defineDestructiveTool } from "./toolDefinition.js";
 
 export const changeContentItemVariantWorkflowStep = defineDestructiveTool(
-  "change-content-item-variant-workflow-step",
-  "Move Kontent.ai content item variant (language version/translation) to a different workflow step. Transition content between lifecycle stages (e.g., draft to review, review to approved/published, or archive).",
+  changeContentItemVariantWorkflowStepToolName,
+  "Move Kontent.ai content item variant (language version/translation) to a different workflow step. Transition content between lifecycle stages (e.g., draft to review, review to approved/published, or archive). Use list-workflows to discover the workflow's steps and their IDs — the workflow's 'steps' are the editable ones, as opposed to the published, scheduled, and archived system steps.",
   {
     itemId: z.guid().describe("Content item ID"),
     languageId: z.guid().describe("Language ID"),

--- a/src/tools/create-new-content-item-variant-version.ts
+++ b/src/tools/create-new-content-item-variant-version.ts
@@ -2,10 +2,11 @@ import { z } from "zod";
 import { createMapiClient } from "../clients/kontentClients.js";
 import { handleMcpToolError } from "../utils/errorHandler.js";
 import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
+import { createNewContentItemVariantVersionToolName } from "./referencedToolNames.js";
 import { defineAdditiveTool } from "./toolDefinition.js";
 
 export const createNewContentItemVariantVersion = defineAdditiveTool(
-  "create-new-content-item-variant-version",
+  createNewContentItemVariantVersionToolName,
   "Create new draft version of a published Kontent.ai content item variant (language version/translation). Required before editing published content.",
   {
     itemId: z.guid().describe("Content item ID"),

--- a/src/tools/get-content-item-translations.ts
+++ b/src/tools/get-content-item-translations.ts
@@ -7,7 +7,7 @@ import { defineReadOnlyTool } from "./toolDefinition.js";
 
 export const getContentItemTranslations = defineReadOnlyTool(
   "get-content-item-translations",
-  `Get all Kontent.ai content item translations — every language version (variant) of a specific content item. Returns each language's current version (draft if one exists, otherwise the last one saved), which may differ from the version currently live on the Delivery API. Retrieve translated content across all languages to examine details of a specific item in translation scenarios, rather than to search for items — for finding or disambiguating among candidates, use ${listContentItemVariantsToolName}'s search_phrase filter.`,
+  `Get all Kontent.ai content item translations — every language version (variant) of a specific content item. Returns each language's current version (draft if one exists, otherwise the last one saved), which may differ from the version currently live on the Delivery API. Retrieve translated content across all languages to examine details of a specific item in translation scenarios, rather than to search for items — for finding or disambiguating among candidates, use ${listContentItemVariantsToolName}'s search_phrase filter. Each variant includes 'agent_metadata.editability': 'is_editable' plus plain-text 'guidance' naming the operation required first when a variant is not directly editable.`,
   {
     itemId: z.string().describe("Content item ID"),
   },
@@ -18,6 +18,7 @@ export const getContentItemTranslations = defineReadOnlyTool(
       const response = await client
         .listLanguageVariantsOfItem()
         .byItemId(itemId)
+        .withAgentMetadata()
         .toPromise();
 
       return createMcpToolSuccessResponse(response.rawData);

--- a/src/tools/get-content-item-variant.ts
+++ b/src/tools/get-content-item-variant.ts
@@ -6,7 +6,7 @@ import { defineReadOnlyTool } from "./toolDefinition.js";
 
 export const getContentItemVariant = defineReadOnlyTool(
   "get-content-item-variant",
-  `Retrieve a single Kontent.ai content item variant (language version/translation) by item and language ID. Returns the current version — draft if one exists, otherwise published.`,
+  `Retrieve a single Kontent.ai content item variant (language version/translation) by item and language ID. Returns the current version — draft if one exists, otherwise published. The response includes 'agent_metadata.editability': 'is_editable' plus plain-text 'guidance' naming the operation required first when the variant is not directly editable.`,
   {
     itemId: z.string().describe("Content item ID"),
     languageId: z.string().describe("Language ID"),
@@ -19,6 +19,7 @@ export const getContentItemVariant = defineReadOnlyTool(
         .viewLanguageVariant()
         .byItemId(itemId)
         .byLanguageId(languageId)
+        .withAgentMetadata()
         .toPromise();
 
       return createMcpToolSuccessResponse(response.rawData);

--- a/src/tools/get-published-content-item-variant-version.ts
+++ b/src/tools/get-published-content-item-variant-version.ts
@@ -6,7 +6,7 @@ import { defineReadOnlyTool } from "./toolDefinition.js";
 
 export const getPublishedContentItemVariantVersion = defineReadOnlyTool(
   "get-published-content-item-variant-version",
-  "Retrieve the published (live) version and details of a Kontent.ai content item variant, exactly as served on the Delivery API right now, even when a newer draft version exists.",
+  "Retrieve the published (live) version and details of a Kontent.ai content item variant, exactly as served on the Delivery API right now, even when a newer draft version exists. This snapshot is read-only; 'agent_metadata.editability.guidance' in the response states what to do instead.",
   {
     itemId: z.string().describe("Content item ID"),
     languageId: z.string().describe("Language ID"),
@@ -20,6 +20,7 @@ export const getPublishedContentItemVariantVersion = defineReadOnlyTool(
         .byItemId(itemId)
         .byLanguageId(languageId)
         .published()
+        .withAgentMetadata()
         .toPromise();
 
       return createMcpToolSuccessResponse(response.rawData);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 import { bulkGetContentItemVariants } from "./bulk-get-content-item-variants.js";
+import { cancelScheduledPublishingContentItemVariant } from "./cancel-scheduled-publishing-content-item-variant.js";
 import { changeContentItemVariantWorkflowStep } from "./change-content-item-variant-workflow-step.js";
 import { createContentItem } from "./create-content-item.js";
 import { createContentItemVariant } from "./create-content-item-variant.js";
@@ -60,6 +61,7 @@ export const allTools = {
   createTaxonomyGroup,
   createWorkflow,
   bulkGetContentItemVariants,
+  cancelScheduledPublishingContentItemVariant,
   changeContentItemVariantWorkflowStep,
   createContentItemVariant,
   createNewContentItemVariantVersion,

--- a/src/tools/referencedToolNames.ts
+++ b/src/tools/referencedToolNames.ts
@@ -6,6 +6,12 @@ export const bulkGetContentItemVariantsToolName =
 export const createContentItemToolName = "create-content-item";
 export const createContentItemVariantToolName = "create-content-item-variant";
 export const updateContentItemVariantToolName = "update-content-item-variant";
+export const createNewContentItemVariantVersionToolName =
+  "create-new-content-item-variant-version";
+export const cancelScheduledPublishingContentItemVariantToolName =
+  "cancel-scheduled-publishing-content-item-variant";
+export const changeContentItemVariantWorkflowStepToolName =
+  "change-content-item-variant-workflow-step";
 export const getPatchGuideToolName = "get-patch-guide";
 export const getPublishedContentItemVariantVersionToolName =
   "get-published-content-item-variant-version";


### PR DESCRIPTION
### Motivation

No GitHub issue — internal ref EN-786 ("MCP server — unable to update published variant").

The problem. get-content-item-variant returned the variant's workflow step but nothing about whether the variant could actually be written to. So an agent asked to edit content discovered the problem only after a failed upsert — and the Management API's error for a published variant offers either creating a new version or unpublishing it. Unpublishing is destructive and almost never what was intended, so the recovery path itself was a hazard.

The fix. MAPI now classifies the variant and returns plain-text guidance, opted into with a header. Four read tools request it and pass it straight through:

- get-content-item-variant
- get-content-item-translations
- bulk-get-content-item-variants
- get-published-content-item-variant-version

Each variant comes back with agent_metadata.editability = { is_editable, guidance }, where guidance names the operation to perform first. This PR also adds cancel-scheduled-publishing-content-item-variant, because the guidance for a scheduled variant named an operation that had no tool.

Why the API classifies this instead of the server. MAPI already resolves the variant's workflow, so it handles environments whose workflow carries a published step that isn't one of the well-known IDs, plus the Archived step. Doing it here would mean matching hard-coded step GUIDs against a workflow this server never fetches.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
