### PR TITLE
Enhance content item variant responses with editability metada…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ npx @kontent-ai/mcp-server@latest shttp
 * **change-content-item-variant-workflow-step** – Change the workflow step of a content item variant in Kontent.ai. This operation moves a content item variant to a different step in the workflow, enabling content lifecycle management such as moving content from draft to review, review to published, etc.
 * **publish-content-item-variant** – Publish or schedule a content item variant of a content item in Kontent.ai. This operation can either immediately publish the variant or schedule it for publication at a specific future date and time with optional timezone specification
 * **unpublish-content-item-variant** – Unpublish or schedule unpublishing of a content item variant of a content item in Kontent.ai. This operation can either immediately unpublish the variant (making it unavailable through the Delivery API) or schedule it for unpublishing at a specific future date and time with optional timezone specification
+* **cancel-scheduled-publishing-content-item-variant** – Cancel scheduled publishing of a content item variant in Kontent.ai. This operation reverts a variant that was scheduled for publishing back to its previous workflow step, enabling further edits
 
 ## ⚙️ Configuration
 

--- a/src/clients/kontentClients.ts
+++ b/src/clients/kontentClients.ts
@@ -4,6 +4,11 @@ import { throwError } from "../utils/throwError.js";
 
 const sourceTrackingHeaderName = "X-KC-SOURCE";
 
+export const agentMetadataHeader = {
+  header: "X-KC-Agent-Metadata",
+  value: "true",
+};
+
 /**
  * Creates a Kontent.ai Management API client
  * @param environmentId Optional environment ID (defaults to process.env.KONTENT_ENVIRONMENT_ID)

--- a/src/test/bm25/toolSearchBm25.spec.ts
+++ b/src/test/bm25/toolSearchBm25.spec.ts
@@ -736,6 +736,19 @@ const testGroups: ReadonlyArray<TestGroup> = [
         query: "take content offline",
         expected: [allTools.unpublishContentItemVariant.name],
       },
+      // cancel scheduled publishing
+      {
+        query: "cancel scheduled publishing",
+        expected: [allTools.cancelScheduledPublishingContentItemVariant.name],
+      },
+      {
+        query: "cancel schedule publish",
+        expected: [allTools.cancelScheduledPublishingContentItemVariant.name],
+      },
+      {
+        query: "revert scheduled content",
+        expected: [allTools.cancelScheduledPublishingContentItemVariant.name],
+      },
       // Synonym: approve / review / lifecycle / archive
       {
         query: "approve content review",

--- a/src/test/security/server.spec.ts
+++ b/src/test/security/server.spec.ts
@@ -14,6 +14,7 @@ type ToolKind = "read-only" | "additive" | "destructive" | "unknown";
 const READ_ONLY_PREFIXES = ["bulk-get-", "get-", "list-", "search-"];
 const ADDITIVE_PREFIXES = ["create-"];
 const DESTRUCTIVE_PREFIXES = [
+  "cancel-",
   "change-",
   "delete-",
   "patch-",

--- a/src/tools/bulk-get-content-item-variants.ts
+++ b/src/tools/bulk-get-content-item-variants.ts
@@ -1,4 +1,7 @@
-import { createMapiClient } from "../clients/kontentClients.js";
+import {
+  agentMetadataHeader,
+  createMapiClient,
+} from "../clients/kontentClients.js";
 import { bulkGetItemsWithVariantsSchema } from "../schemas/bulkGetItemsWithVariantsSchemas.js";
 import { handleMcpToolError } from "../utils/errorHandler.js";
 import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
@@ -22,9 +25,12 @@ export const bulkGetContentItemVariants = defineReadOnlyTool(
 
       const client = createMapiClient(environmentId, token);
 
-      const query = client.bulkGetItemsWithVariants().withData({
-        variants,
-      });
+      const query = client
+        .bulkGetItemsWithVariants()
+        .withData({
+          variants,
+        })
+        .withHeader(agentMetadataHeader);
 
       const response = await (continuation_token
         ? query.xContinuationToken(continuation_token)

--- a/src/tools/cancel-scheduled-publishing-content-item-variant.ts
+++ b/src/tools/cancel-scheduled-publishing-content-item-variant.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { createMapiClient } from "../clients/kontentClients.js";
+import { handleMcpToolError } from "../utils/errorHandler.js";
+import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
+import { defineDestructiveTool } from "./toolDefinition.js";
+
+export const cancelScheduledPublishingContentItemVariant =
+  defineDestructiveTool(
+    "cancel-scheduled-publishing-content-item-variant",
+    "Cancel scheduled publishing of Kontent.ai content item variant (language version/translation). Reverts variant back to previous workflow step, enabling further edits.",
+    {
+      itemId: z.guid().describe("Content item ID"),
+      languageId: z
+        .guid()
+        .describe(
+          "Language ID (default: 00000000-0000-0000-0000-000000000000)",
+        ),
+    },
+    async ({ itemId, languageId }, { authInfo: { token, clientId } = {} }) => {
+      const client = createMapiClient(clientId, token);
+
+      try {
+        await client
+          .cancelSheduledPublishingOfLanguageVariant()
+          .byItemId(itemId)
+          .byLanguageId(languageId)
+          .toPromise();
+
+        const message = `Successfully canceled scheduled publishing for item variant '${languageId}' of content item '${itemId}'. The variant has been reverted to its previous workflow step and can now be edited.`;
+
+        return createMcpToolSuccessResponse({
+          message,
+          result: {
+            itemId,
+            languageId,
+            action: "canceled_scheduled_publishing",
+            timestamp: new Date().toISOString(),
+          },
+        });
+      } catch (error: any) {
+        return handleMcpToolError(error, "Cancel Scheduled Publishing");
+      }
+    },
+  );

--- a/src/tools/get-content-item-translations.ts
+++ b/src/tools/get-content-item-translations.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { createMapiClient } from "../clients/kontentClients.js";
+import {
+  agentMetadataHeader,
+  createMapiClient,
+} from "../clients/kontentClients.js";
 import { handleMcpToolError } from "../utils/errorHandler.js";
 import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 import { listContentItemVariantsToolName } from "./referencedToolNames.js";
@@ -18,6 +21,7 @@ export const getContentItemTranslations = defineReadOnlyTool(
       const response = await client
         .listLanguageVariantsOfItem()
         .byItemId(itemId)
+        .withHeader(agentMetadataHeader)
         .toPromise();
 
       return createMcpToolSuccessResponse(response.rawData);

--- a/src/tools/get-content-item-variant.ts
+++ b/src/tools/get-content-item-variant.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { createMapiClient } from "../clients/kontentClients.js";
+import {
+  agentMetadataHeader,
+  createMapiClient,
+} from "../clients/kontentClients.js";
 import { handleMcpToolError } from "../utils/errorHandler.js";
 import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 import { defineReadOnlyTool } from "./toolDefinition.js";
@@ -19,6 +22,7 @@ export const getContentItemVariant = defineReadOnlyTool(
         .viewLanguageVariant()
         .byItemId(itemId)
         .byLanguageId(languageId)
+        .withHeader(agentMetadataHeader)
         .toPromise();
 
       return createMcpToolSuccessResponse(response.rawData);

--- a/src/tools/get-published-content-item-variant-version.ts
+++ b/src/tools/get-published-content-item-variant-version.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { createMapiClient } from "../clients/kontentClients.js";
+import {
+  agentMetadataHeader,
+  createMapiClient,
+} from "../clients/kontentClients.js";
 import { handleMcpToolError } from "../utils/errorHandler.js";
 import { createMcpToolSuccessResponse } from "../utils/responseHelper.js";
 import { defineReadOnlyTool } from "./toolDefinition.js";
@@ -20,6 +23,7 @@ export const getPublishedContentItemVariantVersion = defineReadOnlyTool(
         .byItemId(itemId)
         .byLanguageId(languageId)
         .published()
+        .withHeader(agentMetadataHeader)
         .toPromise();
 
       return createMcpToolSuccessResponse(response.rawData);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 import { bulkGetContentItemVariants } from "./bulk-get-content-item-variants.js";
+import { cancelScheduledPublishingContentItemVariant } from "./cancel-scheduled-publishing-content-item-variant.js";
 import { changeContentItemVariantWorkflowStep } from "./change-content-item-variant-workflow-step.js";
 import { createContentItem } from "./create-content-item.js";
 import { createContentItemVariant } from "./create-content-item-variant.js";
@@ -60,6 +61,7 @@ export const allTools = {
   createTaxonomyGroup,
   createWorkflow,
   bulkGetContentItemVariants,
+  cancelScheduledPublishingContentItemVariant,
   changeContentItemVariantWorkflowStep,
   createContentItemVariant,
   createNewContentItemVariantVersion,


### PR DESCRIPTION
Enhance content item variant responses with editability metadata + add tool to cancel scheduled publish

### Motivation

No GitHub issue — internal ref EN-786 ("MCP server — unable to update published variant").

The problem. get-content-item-variant returned the variant's workflow step but nothing about whether the variant could actually be written to. So an agent asked to edit content discovered the problem only after a failed upsert — and the Management API's error for a published variant offers either creating a new version or unpublishing it. Unpublishing is destructive and almost never what was intended, so the recovery path itself was a hazard.

The fix. MAPI now classifies the variant and returns plain-text guidance, opted into with a header. Four read tools request it and pass it straight through:

get-content-item-variant
get-content-item-translations
bulk-get-content-item-variants
get-published-content-item-variant-version
Each variant comes back with agent_metadata.editability = { is_editable, guidance }, where guidance names the operation to perform first. This PR also adds cancel-scheduled-publishing-content-item-variant, because the guidance for a scheduled variant named an operation that had no tool.

Why the API classifies this instead of the server. MAPI already resolves the variant's workflow, so it handles environments whose workflow carries a published step that isn't one of the well-known IDs, plus the Archived step. Doing it here would mean matching hard-coded step GUIDs against a workflow this server never fetches.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
