### PR TITLE
Update note descriptions to clarify expected, default formatting

### DIFF
--- a/src/tools/create-content-item-variant.ts
+++ b/src/tools/create-content-item-variant.ts
@@ -34,7 +34,9 @@ export const createContentItemVariant = defineAdditiveTool(
       .string()
       .max(4000)
       .optional()
-      .describe("Additional plain text only instructions or notes for content creators. Use line breaks/dashes for structure."),
+      .describe(
+        "Additional plain text only instructions or notes for content creators. Use line breaks/dashes for structure.",
+      ),
   },
   async (
     { itemId, languageId, elements, workflow_step_id, note },

--- a/src/tools/create-content-item-variant.ts
+++ b/src/tools/create-content-item-variant.ts
@@ -34,7 +34,7 @@ export const createContentItemVariant = defineAdditiveTool(
       .string()
       .max(4000)
       .optional()
-      .describe("Additional instructions or notes for content creators"),
+      .describe("Additional plain text only instructions or notes for content creators. Use line breaks/dashes for structure."),
   },
   async (
     { itemId, languageId, elements, workflow_step_id, note },

--- a/src/tools/update-content-item-variant.ts
+++ b/src/tools/update-content-item-variant.ts
@@ -27,7 +27,9 @@ export const updateContentItemVariant = defineDestructiveTool(
       .string()
       .max(4000)
       .optional()
-      .describe("Additional plain text only instructions or notes for content creators. Use line breaks/dashes for structure."),
+      .describe(
+        "Additional plain text only instructions or notes for content creators. Use line breaks/dashes for structure.",
+      ),
   },
   async (
     { itemId, languageId, elements, workflow_step_id, note },

--- a/src/tools/update-content-item-variant.ts
+++ b/src/tools/update-content-item-variant.ts
@@ -27,7 +27,7 @@ export const updateContentItemVariant = defineDestructiveTool(
       .string()
       .max(4000)
       .optional()
-      .describe("Additional instructions or notes for content creators"),
+      .describe("Additional plain text only instructions or notes for content creators. Use line breaks/dashes for structure."),
   },
   async (
     { itemId, languageId, elements, workflow_step_id, note },


### PR DESCRIPTION
### Motivation

This helps clarify the expected, default format of a note's value, and it helps prevent the note from being formatted as Markdown if the user's instructions simply ask for the AI to put its summary there. It still allows for Markdown formatting if the user explicitly requests it.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Prompt an AI to do something and then put its summary in the given item variant's note. As an example:
"Analyze the following item's metadata: <item_url>. Add your summary directly as a note to the item."
